### PR TITLE
Add project ideas planner

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
                   <h2>Josephine Wooldridge</h2>
                   <p class="subtitle">Triple major in IT & Software development/engineering. </p>
                   <button class="contact-btn">Get In Touch</button>
+                  <a href="project-ideas.html" class="contact-btn" style="margin-top:0.5rem; display:inline-block;">Project Ideas</a>
                </div>
             </div>
             <!-- TERMINAL -->

--- a/project-ideas.html
+++ b/project-ideas.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Project Ideas | Josephine Wooldridge</title>
+    <link rel="stylesheet" href="styles/main.css">
+    <link rel="stylesheet" href="styles/planner.css">
+</head>
+<body>
+    <div id="sparkle-container"></div>
+    <header>
+        <div class="container">
+            <h1 class="logo">JW</h1>
+            <nav>
+                <ul class="nav-links">
+                    <li><a href="index.html">Home</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <section class="planner-section">
+        <div class="book">
+            <button class="nav-arrow left" aria-label="Previous page">&#10094;</button>
+            <div class="pages">
+                <div class="page">
+                    <h2>Glitch Assistant Suite</h2>
+                    <div class="idea">
+                        <h3>Glitch Assistant</h3>
+                        <p>Voice and memory-integrated AI assistant. Uses OpenAI, Whisper, handwriting OCR and context retrieval. Designed for tablet pairing and smart devices.</p>
+                        <img src="images/josieprofile.png" alt="mockup" class="idea-img">
+                    </div>
+                    <div class="idea">
+                        <h3>Glitch Voice Wake Mode</h3>
+                        <p>Add-on for Glitch Assistant. Wake with a phrase like "Hey Glitch" and respond in-character with memory of past context.</p>
+                    </div>
+                    <div class="idea">
+                        <h3>Note Organizer with Tag Search + Glitch Voice</h3>
+                        <p>Organize project notes with tagging and query them through Glitch.</p>
+                    </div>
+                    <div class="idea">
+                        <h3>Handwriting Screenshot + Voice Trigger System</h3>
+                        <p>Capture tablet screenshots on voice command and feed them into Glitch memory.</p>
+                    </div>
+                </div>
+                <div class="page">
+                    <h2>Game Concepts</h2>
+                    <div class="idea">
+                        <h3>Cursed Kitty</h3>
+                        <p>Cozy-to-dark magical cat adventure with witchcore vibes and emotional storytelling. Built in Godot.</p>
+                    </div>
+                    <div class="idea">
+                        <h3>Wasteland Whirler: Roomba Rampage</h3>
+                        <p>Idle/clicker game about hat-wearing Roombas cleaning a post-apocalyptic world. Also in Godot.</p>
+                    </div>
+                    <div class="idea">
+                        <h3>Expanded Baldur’s Gate 3 Mod / D&D RP Mode</h3>
+                        <p>Long-term dream to host custom campaigns with bigger parties using BG3.</p>
+                    </div>
+                </div>
+                <div class="page">
+                    <h2>AI &amp; Automation Projects</h2>
+                    <div class="idea">
+                        <h3>L0R3.exe (AI Dungeon Master Bot)</h3>
+                        <p>Bot that manages D&D character building, reactions and dice rolls. Fixing broken commands like !lore and !buildcharacter.</p>
+                    </div>
+                    <div class="idea">
+                        <h3>AI Stock Trading Bot</h3>
+                        <p>Automatically invests in top companies using data skimming and pattern detection. Starts with QQQ and VT ETFs.</p>
+                    </div>
+                    <div class="idea">
+                        <h3>TypeFinity</h3>
+                        <p>Word fusion typing game with increasing sass. CLI interface with save/load using pickle. Current version: v0.0.3.</p>
+                    </div>
+                </div>
+                <div class="page">
+                    <h2>Web &amp; School Projects</h2>
+                    <div class="idea">
+                        <h3>Terminal-Style Glassmorphism Website</h3>
+                        <p>Your portfolio site blending retro terminal vibes with modern glass UI.</p>
+                    </div>
+                    <div class="idea">
+                        <h3>FlyMe2TheMoon (VB.NET &amp; SQL Project)</h3>
+                        <p>Flight management simulation with secure login, role menus and stored procedures. Originally a school project.</p>
+                    </div>
+                </div>
+            </div>
+            <button class="nav-arrow right" aria-label="Next page">&#10095;</button>
+        </div>
+    </section>
+    <script src="scripts/sparkle.js" defer></script>
+    <script src="scripts/planner.js" defer></script>
+</body>
+</html>

--- a/scripts/planner.js
+++ b/scripts/planner.js
@@ -1,0 +1,35 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const pages = document.querySelectorAll('.page');
+    const left = document.querySelector('.nav-arrow.left');
+    const right = document.querySelector('.nav-arrow.right');
+    let current = 0;
+
+    function showPage(index) {
+        pages[current].classList.remove('active');
+        pages[current].style.display = 'none';
+        current = (index + pages.length) % pages.length;
+        pages[current].style.display = 'block';
+        pages[current].classList.add('active');
+        sparkleBurst();
+    }
+
+    pages[0].style.display = 'block';
+    pages[0].classList.add('active');
+
+    left.addEventListener('click', () => showPage(current - 1));
+    right.addEventListener('click', () => showPage(current + 1));
+});
+
+function sparkleBurst() {
+    const container = document.getElementById('sparkle-container');
+    const chars = ['☆', '。', '*', '✦', '⁺', '˚', '⋆', '｡', '°', '✩', '₊', '･', 'ﾟ', '✧', '∘', '⊹', '⟡', '˖', '•'];
+    for (let i = 0; i < 25; i++) {
+        const sp = document.createElement('div');
+        sp.className = 'sparkle';
+        sp.textContent = chars[Math.floor(Math.random() * chars.length)];
+        sp.style.left = `${Math.random() * window.innerWidth}px`;
+        sp.style.top = `${Math.random() * window.innerHeight}px`;
+        container.appendChild(sp);
+        setTimeout(() => sp.remove(), 1000);
+    }
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -14,3 +14,4 @@
 @import url('./sparkle.css');
 @import url('./scroll_fade.css');
 @import url('./resume.css');
+@import url('./planner.css');

--- a/styles/planner.css
+++ b/styles/planner.css
@@ -1,0 +1,55 @@
+.planner-section {
+    padding: 6rem 1rem;
+    display: flex;
+    justify-content: center;
+}
+
+.book {
+    position: relative;
+    max-width: 800px;
+    width: 100%;
+}
+
+.pages {
+    position: relative;
+    overflow: hidden;
+}
+
+.page {
+    display: none;
+    background: var(--clr-overlay);
+    border: 1px solid var(--clr-border);
+    border-radius: 12px;
+    padding: 2rem;
+    min-height: 400px;
+    transform-origin: left;
+}
+
+.page.active {
+    display: block;
+    animation: pageFlip 0.6s ease forwards;
+}
+
+.nav-arrow {
+    background: var(--clr-accent);
+    color: #000;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 50%;
+    cursor: pointer;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 10;
+}
+
+.nav-arrow.left { left: -3rem; }
+.nav-arrow.right { right: -3rem; }
+
+.idea { margin-bottom: 1.5rem; }
+.idea-img { width: 100%; border-radius: 8px; margin-top: 0.5rem; }
+
+@keyframes pageFlip {
+    from { transform: rotateY(-90deg); }
+    to { transform: rotateY(0deg); }
+}


### PR DESCRIPTION
## Summary
- list project ideas on new planner page
- add page flip interaction with sparkles
- style planner as part of site theme
- link to planner from index

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688505937d548320b1260ab06ebf3cda